### PR TITLE
feat: Extend nodemailer configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,31 +13,46 @@ npm i strapi-provider-email-nodemailer-v3
 
 In your **config/plugins.js** file:
 ```js
-module.exports = ({env}) => ({
-    email: {
-        provider: "nodemailer-v3",
-        providerOptions: {},
-        settings: {
-            host: 'smtp.example.com',
-            port: 587,
-            username: 'username@example.com',
-            password: 'password',
-            secure: false
-        }
+module.exports = ({ env }) => ({
+  email: {
+    provider: 'nodemailer-v3',
+    providerOptions: {
+      host: env('SMTP_HOST', 'smtp.example.com'),
+      port: env('SMTP_PORT', 587),
+      username: env('SMTP_USERNAME'),
+      password: env('SMTP_PASSWORD'),
+      // ... any custom nodemailer options
+    },
+    settings: {
+      defaultFrom: 'hello@example.com',
+      defaultReplyTo: 'hello@example.com',
     }
-})
+  },
+});
 ```
 
-| Field  | Description |
-| ------------- | ------------- |
-| nodemailer_default_from | Default sender address if none is provided  |
-| nodemailer_default_reply_to | Default responder address if none is provided  |
-| host | hostname or IP address to connect to (smtp.your-server.com)  |
-| port | port to connect to (in most cases: 587, 465 or 25)  |
-| username | authorization username |
-| password | authorization password  |
-| secure | if true the connection will use TLS when connecting to server. If false (the default) then TLS is used if server supports the STARTTLS extension. In most cases set this value to true if you are connecting to port 465. For port 587 or 25, keep it false |
-| auth_method | currently there are 2 Authentication Methods available:<br>SMTP (Plain and Login) and NLMT |
+Check out the available options for nodemailer: https://nodemailer.com/about/
+
+You can override the default configurations for specific environments. E.g. for
+`NODE_ENV=development` in **config/env/development/plugins.js**:
+```js
+module.exports = ({ env }) => ({
+  email: {
+    provider: 'nodemailer-v3',
+    providerOptions: {
+      host: 'localhost',
+      port: 1025,
+      ignoreTLS: true,
+    },
+  },
+});
+```
+The above setting is useful for local development with
+[maildev](https://github.com/maildev/maildev).
+
+
+## Usage
+
 
 To send an email from anywhere inside Strapi:
 ```js

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,56 +11,25 @@ const _ = require('lodash')
 const nodemailer = require('nodemailer')
 const nodemailerNTLMAuth = require('nodemailer-ntlm-auth');
 
-/**
- * Converts a string to a bool.
- *  - match 'true', 'on', or '1' as true.
- *  - ignore all white-space padding
- *  - ignore capitalization (case).
- **/
-const toBool = val => /^\s*(true|1|on)\s*$/i.test(val);
-
-/* eslint-disable no-unused-vars */
 module.exports = {
   provider: 'nodemailer-v3',
   name: 'Nodemailer',
 
   init: (providerOptions = {}, settings = {}) => {
-    let transporter;
-
-    if (settings.authMethod === 'ntlm'){
-      transporter = nodemailer.createTransport({
-        host: settings.host,
-        port: settings.port,
-        secure: toBool(settings.secure),
-        auth: {
-          type: 'custom',
-          method: 'NTLM',
-          user: settings.username,
-          pass: settings.password
-        },
-        customAuth: {
-          NTLM: nodemailerNTLMAuth
-        }
-      });
-    }else{
-      transporter = nodemailer.createTransport({
-        host: settings.host,
-        port: settings.port,
-        secure: toBool(settings.secure),
-        auth: {
-          user: settings.username,
-          pass: settings.password
-        }
-      })
+    if (providerOptions.auth && providerOptions.auth.method === 'NTLM'){
+      providerOptions.customAuth = {
+        NTLM: nodemailerNTLMAuth
+      }
     }
+    const transporter = nodemailer.createTransport(providerOptions);
 
     return {
       send: (options) => {
         return new Promise((resolve, reject) => {
           // Default values.
           options = _.isObject(options) ? options : {}
-          options.from = options.from || settings.nodemailer_default_from
-          options.replyTo = options.replyTo || settings.nodemailer_default_reply_to
+          options.from = options.from || settings.defaultFrom
+          options.replyTo = options.replyTo || settings.defaultReplyTo
           options.text = options.text || options.html
           options.html = options.html || options.text
 


### PR DESCRIPTION
It took me a day to get my head through:
* Strapi v3.x version confusion
* Strapi plugin configuration
* the outdated nodemailer provider https://www.npmjs.com/package/strapi-provider-email-nodemailer
* this v3 compatible provider
* and finally how to configure this npm package for a local SMTP server (maildev)

My questions:
* can we release after this PR?
* can we send a PR from this repo into the outdated `nodemailer` provider?
* can we ask Strapi developers to maintain a nodemailer provider?

Regarding this PR:
* I haven't tested NTLM
* I changed the names of the parameters slightly (defaultFrom) because apparently Strapi itself provides a `defaultFrom` option